### PR TITLE
Update to 1.0.5

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,8 +22,8 @@ requirements:
   run:
     - importlib_resources
     - python
-    - pytest
-    - pytest-nunit
+    - pytest >=5.0.0
+    - pytest-nunit >=1.0.0,<2.0.0
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -30,9 +30,9 @@ test:
     - importlib_resources
     - pip
   commands:
+    - pip install pytest-nunit
     - pip check
-    - python test/test_azurepipelines.py
-    # - "py.test --traceconfig | grep pytest-azurepipelines-{{ version }}"
+    - "py.test --traceconfig | grep pytest-azurepipelines-{{ version }}"
 
 about:
   home: https://github.com/tonybaloney/pytest-azurepipelines

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,12 +12,13 @@ source:
 build:
   noarch: python
   number: 0
-  script: "{{ PYTHON }} -m pip install . --no-deps -vv"
+  script: "{{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv"
 
 requirements:
   host:
     - python
     - pip
+    - wheel
   run:
     - python
     - pytest
@@ -28,6 +29,7 @@ test:
   requires:
     - importlib_resources
   commands:
+    - pip check
     - python test/test_azurepipelines.py
     # - "py.test --traceconfig | grep pytest-azurepipelines-{{ version }}"
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,17 +20,17 @@ requirements:
     - pip
     - wheel
   run:
+    - importlib_resources
     - python
     - pytest
+    - pytest-nunit
 
 test:
   imports:
     - pytest_azurepipelines
   requires:
-    - importlib_resources
     - pip
   commands:
-    - pip install pytest-nunit
     - pip check
     - "py.test --traceconfig | grep pytest-azurepipelines-{{ version }}"
 
@@ -40,7 +40,6 @@ about:
   license_family: MIT
   license_file: LICENSE
   summary: 'Plugin for pytest that makes it simple to work with Azure Pipelines'
-
   description: |
     Making Pytest easier to use with Microsoft Azure Pipelines. Just run pytest with
     this plugin and see your test results in the Azure Pipelines UI!

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "pytest-azurepipelines" %}
-{% set version = "0.8.0" %}
+{% set version = "1.0.5" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 944ae2c0790b792d123aa7312fe307bc35214dd26531728923ae5085a1d1feab
+  sha256: fd08f089bca0fad3c2b6fde9dbea69b975492ffaa8cb637cc987e64af8c18b9c
 
 build:
   noarch: python
@@ -25,8 +25,11 @@ requirements:
 test:
   imports:
     - pytest_azurepipelines
+  requires:
+    - importlib_resources
   commands:
-    - "py.test --traceconfig | grep pytest-azurepipelines-{{ version }}"
+    - python test/test_azurepipelines.py
+    # - "py.test --traceconfig | grep pytest-azurepipelines-{{ version }}"
 
 about:
   home: https://github.com/tonybaloney/pytest-azurepipelines

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,6 +28,7 @@ test:
     - pytest_azurepipelines
   requires:
     - importlib_resources
+    - pip
   commands:
     - pip check
     - python test/test_azurepipelines.py


### PR DESCRIPTION
pytest-azurebuildpipelines 1.0.5

**Destination channel:** defaults

### Links

- [PKG-7053](https://anaconda.atlassian.net/browse/PKG-7053) 
- [Upstream repository](https://github.com/tonybaloney/pytest-azurepipelines)
- [Upstream changelog/diff](https://github.com/tonybaloney/pytest-azurepipelines/blob/master/HISTORY.rst)
- Relevant dependency PRs:

### Explanation of changes:
- Updated version to 1.0.5
- Updated tests

[PKG-7053]: https://anaconda.atlassian.net/browse/PKG-7053?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ